### PR TITLE
fix(kmain): guard NULL init_node and free buf on exec failure

### DIFF
--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -412,15 +412,17 @@ void kmain(void) {
                 else if (init_node->data)
                     memcpy(buf, init_node->data, fsize);
                 buf[fsize] = '\0';
-                if (process_exec(buf, fsize, "/init") < 0)
+                if (process_exec(buf, fsize, "/init") < 0) {
                     kprintf("  FATAL: process_exec failed\n");
+                    kfree(buf);
+                }
             } else {
                 kprintf("  FATAL: out of memory for /init\n");
             }
         } else {
             kprintf("  FATAL: /init not found\n");
         }
-        vfs_node_unref_internal(init_node);
+        if (init_node) vfs_node_unref_internal(init_node);
     }
 
     vfs_sync_all();


### PR DESCRIPTION
Prevents two potential bugs

1 If /init /sbin/init and /bin/init are all missing init_node
  remained NULL but was still passed to vfs_node_unref_internal()
  which could cause a NULL pointer dereference and crash the kernel

2 If process_exec() returned an error the buffer (buf) allocated for
  the /init image was never freed via kfree() leading to a memory
  leak on failed init process startup

Fix
vfs_node_unref_internal(init_node) is now only called when if (init_node) is true
added kfree(buf) in the process_exec() failure branch

Existing comments in the code were not removed and no new comments were added changes are strictly localized to these two fixes