### PR TITLE
fix(ptrace): preserve orig_rax across syscall exit

### DIFF
--- a/kernel/arch/x86_64/idt.c
+++ b/kernel/arch/x86_64/idt.c
@@ -204,6 +204,7 @@ void isr_dispatch(cpu_state_t *state) {
 
             if ((n == 1 || n == 3) && g_current_proc->tracer_pid) {
                 if (n == 3 && state->rip) state->rip--; /* int3 leaves rip past the opcode */
+                g_current_proc->ptrace_orig_rax = state->rax;
                 proc_ptrace_stop(g_current_proc, SIGTRAP, 2, state, &state->rflags);
                 return;
             }

--- a/kernel/proc/proc.h
+++ b/kernel/proc/proc.h
@@ -64,7 +64,6 @@ typedef struct proc {
     uint32_t jail_id;     /* 0 = host; appended at end so sched.S offsets stay fixed */
     uint8_t jail_exempt;  /* inherited; init=1, suppresses auto-isolation */
 
-    /* ptrace(2) state, appended so the offsets asserted in proc.c/sched.S never move */
     uint32_t tracer_pid;        /* 0 = not traced */
     uint8_t ptrace_stopped;     /* currently in ptrace-stop, waiting for tracer */
     uint8_t ptrace_reported;    /* this stop was already handed back via wait4 */
@@ -74,6 +73,8 @@ typedef struct proc {
     uint8_t ptrace_step;         /* one-shot: set TF before next resume (PTRACE_SINGLESTEP) */
     uint8_t ptrace_frame_kind;   /* 0=none, 1=syscall_frame_t*, 2=cpu_state_t* */
     void *ptrace_frame;          /* frame the tracee is stopped in, valid while stopped */
+    uint64_t ptrace_orig_rax;    /* syscall nr as of entry; rax itself gets clobbered by the
+                                   * return value before an exit-stop can report it */
 } proc_t;
 
 extern proc_t g_proctable[PROC_MAX] __attribute__((aligned(16)));

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -919,7 +919,7 @@ static void ptrace_fill_regs(proc_t *t, struct ptrace_user_regs *out) {
         out->rdx = f->rdx;
         out->rsi = f->rsi;
         out->rdi = f->rdi;
-        out->orig_rax = f->rax;
+        out->orig_rax = t->ptrace_orig_rax;
         out->rip = f->rcx;
         out->eflags = f->r11;
     } else if (t->ptrace_frame_kind == 2) {
@@ -939,7 +939,7 @@ static void ptrace_fill_regs(proc_t *t, struct ptrace_user_regs *out) {
         out->rdx = s->rdx;
         out->rsi = s->rsi;
         out->rdi = s->rdi;
-        out->orig_rax = s->rax;
+        out->orig_rax = t->ptrace_orig_rax;
         out->rip = s->rip;
         out->cs = s->cs;
         out->eflags = s->rflags;
@@ -2073,6 +2073,7 @@ void syscall_dispatch(syscall_frame_t *f) {
     uint64_t a4 = f->r10, a5 = f->r8, a6 = f->r9;
 
     proc_t *tp = cur();
+    if (tp) tp->ptrace_orig_rax = nr;
     if (tp && tp->ptrace_syscall_trace && nr != 101) {
         tp->ptrace_in_syscall = 1;
         proc_ptrace_stop(tp, SIGTRAP | 0x80, 1, f, &f->r11);


### PR DESCRIPTION
Closes #55